### PR TITLE
修复数据库下载地址，使用方式增加`Docker`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:alpine AS builder
+
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64 \
+    GOPROXY=https://goproxy.cn,direct
+
+WORKDIR /app
+COPY . .
+
+#增加缺失的包，移除没用的包
+RUN go mod tidy
+RUN go build -o main .
+# 下载最新的数据库
+RUN wget https://github.do/https://raw.githubusercontent.com/bqf9979/ip2region/master/data/ip2region.db
+
+
+FROM scratch
+# FROM alpine
+WORKDIR /app
+COPY --from=builder /app/main /app
+COPY --from=builder /app/ip2region.db /app
+EXPOSE 9090
+ENTRYPOINT  ["/app/main"]

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"strings"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -112,11 +112,10 @@ func queryIp(w http.ResponseWriter, r *http.Request) {
 	}
 	
 	// 分割字符串
-	result := []struct{}
+	result := []IpInfo{}
 	ip_arr := strings.Split(ip,",")
 	for _,ip := range ip_arr{
 		info, searchErr := region.MemorySearch(ip)
-
 		if searchErr != nil {
 			msg, _ := json.Marshal(JsonRes{Code: 4002, Msg: searchErr.Error()})
 			w.Write(msg)
@@ -124,15 +123,16 @@ func queryIp(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// 赋值查询结果
-		result = append(result,&IpInfo{
-			Ip:       ip,
-			ISP:      info.ISP,
-			Country:  info.Country,
-			Province: info.Province,
-			City:     info.City,
-			County:   "",
-			Region:   info.Region,
-		})
+		ipinfo := &IpInfo{
+                        Ip:       ip,
+                        ISP:      info.ISP,
+                        Country:  info.Country,
+                        Province: info.Province,
+                        City:     info.City,
+                        County:   "",
+                        Region:   info.Region,
+                } 
+		result = append(result,*ipinfo)
 	}
 	msg, _ := json.Marshal(JsonRes{Code: 200, Data: result})
 	w.Write(msg)

--- a/main.go
+++ b/main.go
@@ -17,8 +17,8 @@ var (
 	port = ""
 	d    = "" // 下载标识
 	dbUrl = map[string]string{
-		"1": "https://hub.fastgit.org/lionsoul2014/ip2region/raw/master/data/ip2region.db",
-		"2": "https://hub.fastgit.org/bqf9979/ip2region/raw/master/data/ip2region.db",
+		"1": "https://github.do/https://raw.githubusercontent.com/lionsoul2014/ip2region/raw/master/data/ip2region.db",
+		"2": "https://github.do/https://raw.githubusercontent.com/bqf9979/ip2region/raw/master/data/ip2region.db",
 	}
 )
 
@@ -44,7 +44,7 @@ type IpInfo struct {
 }
 
 func init() {
-	_p := flag.String("p", "80", "本地监听的端口")
+	_p := flag.String("p", "9090", "本地监听的端口")
 	_d := flag.String("d", "0", "仅用于下载最新的ip地址库，保存在当前目录")
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ var (
 
 const (
 	ipDbPath = "./ip2region.db"
-	defaultDbUrl = "1" // 默认下载 来自 lionsoul2014 仓库的 ip db文件
+	defaultDbUrl = "2" // 默认下载 来自 bqf9979 仓库的 ip db文件,在维护，且有付费资源
 )
 
 type JsonRes struct {
@@ -44,7 +44,7 @@ type IpInfo struct {
 }
 
 func init() {
-	_p := flag.String("p", "9090", "本地监听的端口")
+	_p := flag.String("p", "80", "本地监听的端口")
 	_d := flag.String("d", "0", "仅用于下载最新的ip地址库，保存在当前目录")
 	flag.Parse()
 
@@ -66,7 +66,7 @@ func init() {
 func main() {
 	http.HandleFunc("/", queryIp)
 
-	link := "http://127.0.0.1:" + port
+	link := "http://0.0.0.0:" + port
 
 	log.Println("监听端口", link)
 	listenErr := http.ListenAndServe(":"+port, nil)

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 }
 
 func queryIp(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("content-type", "text/json")
+	w.Header().Set("content-type", "text/json;charset=utf-8")
 
 	defer func() {
 		//捕获 panic

--- a/main.go
+++ b/main.go
@@ -109,27 +109,31 @@ func queryIp(w http.ResponseWriter, r *http.Request) {
 		w.Write(msg)
 		return
 	}
+	
+	// 分割字符串
+	result := []struct{}
+	ip_arr := strings.Split(ip,",")
+	for _,ip := range ip_arr{
+		info, searchErr := region.MemorySearch(ip)
 
-	info, searchErr := region.MemorySearch(ip)
+		if searchErr != nil {
+			msg, _ := json.Marshal(JsonRes{Code: 4002, Msg: searchErr.Error()})
+			w.Write(msg)
+			return
+		}
 
-	if searchErr != nil {
-		msg, _ := json.Marshal(JsonRes{Code: 4002, Msg: searchErr.Error()})
-		w.Write(msg)
-		return
+		// 赋值查询结果
+		result = append(result,&IpInfo{
+			Ip:       ip,
+			ISP:      info.ISP,
+			Country:  info.Country,
+			Province: info.Province,
+			City:     info.City,
+			County:   "",
+			Region:   info.Region,
+		})
 	}
-
-	// 赋值查询结果
-	ipInfo := &IpInfo{
-		Ip:       ip,
-		ISP:      info.ISP,
-		Country:  info.Country,
-		Province: info.Province,
-		City:     info.City,
-		County:   "",
-		Region:   info.Region,
-	}
-
-	msg, _ := json.Marshal(JsonRes{Code: 200, Data: ipInfo})
+	msg, _ := json.Marshal(JsonRes{Code: 200, Data: result})
 	w.Write(msg)
 	return
 }

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,16 @@ Usage of D:\go-ip2region\go-ip2region_windows_amd64.exe:
   -p string
         本地监听的端口 (default "9090")
 ```
+### Docker
+```bash
+// 克隆项目
+git clone https://github.com/hezhizheng/go-ip2region.git
+cd go-ip2region
+// 构建镜像
+docker build -t go-ip2region:latest
+// 运行镜像
+docker run -itd --name=ipinfo -p 9090:9090 go-ip2region:latest
+```
 
 ## 启动http服务
 ```


### PR DESCRIPTION
- 两个数据库的下载地址貌似都失效了

- 新增 `Dockerfile` 构建镜像及 `readme.md` 使用中新增相应说明